### PR TITLE
Allow creators to produce / consume a slice of LocalObjectReference for pull secrets.

### DIFF
--- a/pkg/apis/caching/v1alpha1/image_types.go
+++ b/pkg/apis/caching/v1alpha1/image_types.go
@@ -66,10 +66,10 @@ type ImageSpec struct {
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
-	// ImagePullSecrets is the name of the Kubernetes Secret containing login information
-	// used by the Pods which will run this container.
+	// ImagePullSecrets contains the names of the Kubernetes Secrets containing login
+	// information used by the Pods which will run this container.
 	// +optional
-	ImagePullSecrets *corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
 // ImageConditionType is used to communicate the status of the reconciliation process.

--- a/pkg/apis/caching/v1alpha1/image_validation.go
+++ b/pkg/apis/caching/v1alpha1/image_validation.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 
@@ -34,9 +36,9 @@ func (rs *ImageSpec) Validate() *apis.FieldError {
 	// TODO(mattmoor): Consider using go-containerregistry to validate
 	// the image reference.  This is effectively the function we want.
 	// https://github.com/google/go-containerregistry/blob/2f3e3e1/pkg/name/ref.go#L41
-	if rs.ImagePullSecrets != nil {
-		if equality.Semantic.DeepEqual(rs.ImagePullSecrets, &corev1.LocalObjectReference{}) {
-			return apis.ErrMissingField("imagePullSecrets.name")
+	for index, ips := range rs.ImagePullSecrets {
+		if equality.Semantic.DeepEqual(ips, corev1.LocalObjectReference{}) {
+			return apis.ErrMissingField(fmt.Sprintf("imagePullSecrets[%d].name", index))
 		}
 	}
 	return nil

--- a/pkg/apis/caching/v1alpha1/image_validation_test.go
+++ b/pkg/apis/caching/v1alpha1/image_validation_test.go
@@ -47,10 +47,10 @@ func TestImageValidation(t *testing.T) {
 		r: &Image{
 			Spec: ImageSpec{
 				Image:            "busybox",
-				ImagePullSecrets: &corev1.LocalObjectReference{},
+				ImagePullSecrets: []corev1.LocalObjectReference{{}},
 			},
 		},
-		want: apis.ErrMissingField("spec.imagePullSecrets.name"),
+		want: apis.ErrMissingField("spec.imagePullSecrets[0].name"),
 	}}
 
 	for _, test := range tests {

--- a/pkg/apis/caching/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/caching/v1alpha1/zz_generated.deepcopy.go
@@ -108,8 +108,8 @@ func (in *ImageSpec) DeepCopyInto(out *ImageSpec) {
 	*out = *in
 	if in.ImagePullSecrets != nil {
 		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
-		*out = new(v1.LocalObjectReference)
-		**out = **in
+		*out = make([]v1.LocalObjectReference, len(*in))
+		copy(*out, *in)
 	}
 	return
 }


### PR DESCRIPTION
PodSpec has this as a slice, and if we wanted to start creating these references more automatically for e.g. Deployment it isn't immediately obvious which secret is used for which image (certainly without reading the secrets).  This changes it to a more pass-through model for simplicity.

Fixes: https://github.com/knative/caching/issues/9