### PR TITLE
Remove images deletion step from e2e test / Update test-infra

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -133,11 +133,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:00f434f614520a4b48ef3f6d3ed5c7a1a4f89be1bed98c250711413f6da2eb51"
+  digest = "1:09521a823a008f7df66962ac2637c22e1cdc842ebfcc7a083c444d35258986f7"
   name = "github.com/knative/test-infra"
   packages = ["."]
   pruneopts = "T"
-  revision = "c21d3a832727d5d4334e734c0878eac3a5a07ae7"
+  revision = "7ed32409fa2c447a44a4281f0022ab25ce955f51"
 
 [[projects]]
   digest = "1:2f42fa12d6911c7b7659738758631bec870b7e9b4c6be5444f963cdcfccc191f"

--- a/vendor/github.com/knative/test-infra/scripts/README.md
+++ b/vendor/github.com/knative/test-infra/scripts/README.md
@@ -1,3 +1,200 @@
 # Helper scripts
 
-This directory contains helper scripts used by Prow test jobs, as well and local development scripts.
+This directory contains helper scripts used by Prow test jobs, as well and
+local development scripts.
+
+## Using the `presubmit-tests.sh` helper script
+
+This is a helper script to run the presubmit tests. To use it:
+
+1. Source this script.
+
+1. Define the functions `build_tests()` and `unit_tests()`. They should run all
+tests (i.e., not fail fast), and return 0 if all passed, 1 if a failure
+occurred. The environment variables `RUN_BUILD_TESTS`, `RUN_UNIT_TESTS` and
+`RUN_INTEGRATION_TESTS` are set to 0 (false) or 1 (true) accordingly. If
+`--emit-metrics` is passed, `EMIT_METRICS` will be set to 1.
+
+1. [optional] Define the function `integration_tests()`, just like the previous
+ones. If you don't define this function, the default action for running the
+integration tests is to call the `./test/e2e-tests.sh` script (passing the
+`--emit-metrics` flag if necessary).
+
+1. [optional] Define the functions `pre_integration_tests()` or
+`post_integration_tests()`. These functions will be called before or after the
+integration tests (either your custom one or the default action) and will cause
+the test to fail if they don't return success.
+
+1. Call the `main()` function passing `$@` (without quotes).
+
+Running the script without parameters, or with the `--all-tests` flag causes
+all tests to be executed, in the right order (i.e., build, then unit, then
+integration tests).
+
+Use the flags `--build-tests`, `--unit-tests` and `--integration-tests` to run
+a specific set of tests. The flag `--emit-metrics` is used to emit metrics when
+running the tests, and is automatically handled by the default action (see
+above).
+
+### Sample presubmit test script
+
+```bash
+source vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+
+function build_tests() {
+  go build .
+}
+
+function unit_tests() {
+  report_go_test .
+}
+
+function pre_integration_tests() {
+  echo "Cleaning up before integration tests"
+  rm -fr ./staging-area
+}
+
+# We use the default integration test runner.
+
+main $@
+```
+
+## Using the `e2e-tests.sh` helper script
+
+This is a helper script for Knative E2E test scripts. To use it:
+
+1. Source the script.
+
+1. [optional] Write the `teardown()` function, which will tear down your test
+resources.
+
+1. [optional] Write the `dump_extra_cluster_state()` function. It will be
+called when a test fails, and can dump extra information about the current state
+of the cluster (tipically using `kubectl`).
+
+1. [optional] Write the `parse_flags()` function. It will be called whenever an
+unrecognized flag is passed to the script, allowing you to define your own flags.
+The function must return 0 if the flag is unrecognized, or the number of items
+to skip in the command line if the flag was parsed successfully. For example,
+return 1 for a simple flag, and 2 for a flag with a parameter.
+
+1. Call the `initialize()` function passing `$@` (without quotes).
+
+1. Write logic for the end-to-end tests. Run all go tests using `go_test_e2e()`
+(or `report_go_test()` if you need a more fine-grained control) and call
+`fail_test()` or `success()` if any of them failed. The environment variables
+`DOCKER_REPO_OVERRIDE`, `K8S_CLUSTER_OVERRIDE` and `K8S_USER_OVERRIDE` will be set
+according to the test cluster. You can also use the following boolean (0 is false,
+1 is true) environment variables for the logic:
+    * `EMIT_METRICS`: true if `--emit-metrics` was passed.
+    * `USING_EXISTING_CLUSTER`: true if the test cluster is an already existing one,
+and not a temporary cluster created by `kubetest`.
+
+    All environment variables above are marked read-only.
+
+**Notes:**
+
+1. Calling your script without arguments will create a new cluster in the GCP
+project `$PROJECT_ID` and run the tests against it.
+
+1. Calling your script with `--run-tests` and the variables `K8S_CLUSTER_OVERRIDE`,
+`K8S_USER_OVERRIDE` and `DOCKER_REPO_OVERRIDE` set will immediately start the
+tests against the cluster.
+
+1. You can force running the tests against a specific GKE cluster version by using
+the `--cluster-version` flag and passing a X.Y.Z version as the flag value.
+
+### Sample end-to-end test script
+
+This script will test that the latest Knative Serving nightly release works. It
+defines a special flag (`--no-knative-wait`) that causes the script not to
+wait for Knative Serving to be up before running the tests.
+
+```bash
+source vendor/github.com/knative/test-infra/scripts/e2e-tests.sh
+
+function teardown() {
+  echo "TODO: tear down test resources"
+}
+
+function parse_flags() {
+  if [[ "$1" == "--no-knative-wait" ]]; then
+    WAIT_FOR_KNATIVE=0
+    return 1
+  fi
+  return 0
+}
+
+WAIT_FOR_KNATIVE=1
+
+initialize $@
+
+start_latest_knative_serving
+
+if (( WAIT_FOR_KNATIVE )); then
+  wait_until_pods_running knative-serving || fail_test "Knative Serving is not up"
+fi
+
+# TODO: use go_test_e2e to run the tests.
+kubectl get pods || fail_test
+
+success
+```
+
+## Using the `release.sh` helper script
+
+This is a helper script for Knative release scripts. To use it:
+
+1. Source the script.
+
+1. Call the `initialize()` function passing `$@` (without quotes).
+
+1. Call the `run_validation_tests()` function passing the script or executable that
+runs the release validation tests. It will call the script to run the tests unless
+`--skip_tests` was passed.
+
+1. Write logic for the release process. Call `publish_yaml()` to publish the manifest(s),
+`tag_releases_in_yaml()` to tag the generated images, `branch_release()` to branch
+named releases. Use the following boolean (0 is false, 1 is true) and string environment
+variables for the logic:
+    * `RELEASE_VERSION`: contains the release version if `--version` was passed. This
+also overrides the value of the `TAG` variable as `v<version>`.
+    * `RELEASE_BRANCH`: contains the release branch if `--branch` was passed. Otherwise
+it's empty and `master` HEAD will be considered the release branch.
+    * `RELEASE_NOTES`: contains the filename with the release notes if `--release-notes`
+was passed. The release notes is a simple markdown file.
+    * `SKIP_TESTS`: true if `--skip-tests` was passed. This is handled automatically
+by the run_validation_tests() function.
+    * `TAG_RELEASE`: true if `--tag-release` was passed. In this case, the environment
+variable `TAG` will contain the release tag in the form `vYYYYMMDD-<commit_short_hash>`.
+    * `PUBLISH_RELEASE`: true if `--publish` was passed. In this case, the environment
+variable `KO_FLAGS` will be updated with the `-L` option.
+    * `BRANCH_RELEASE`: true if both `--version` and `--publish-release` were passed.
+
+    All boolean environment variables default to false for safety.
+
+    All environment variables above, except `KO_FLAGS`, are marked read-only once
+`initialize()` is called.
+
+### Sample release script
+
+```bash
+source vendor/github.com/knative/test-infra/scripts/release.sh
+
+initialize $@
+
+run_validation_tests ./test/presubmit-tests.sh
+
+# config/ contains the manifests
+KO_DOCKER_REPO=gcr.io/knative-foo
+ko resolve ${KO_FLAGS} -f config/ > release.yaml
+
+tag_images_in_yaml release.yaml $KO_DOCKER_REPO $TAG
+
+if (( PUBLISH_RELEASE )); then
+  # gs://knative-foo hosts the manifest
+  publish_yaml release.yaml knative-foo $TAG
+fi
+
+branch_release "Knative Foo" release.yaml
+```

--- a/vendor/github.com/knative/test-infra/scripts/dummy.go
+++ b/vendor/github.com/knative/test-infra/scripts/dummy.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2018 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scripts
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("This is a dummy go file so `go dep` can be used with knative/test-infra/scripts")
+	fmt.Println("This file can be safely removed if one day this directory contains real, useful go code")
+}

--- a/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
+++ b/vendor/github.com/knative/test-infra/scripts/presubmit-tests.sh
@@ -14,26 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is a helper script to run the presubmit tests. To use it:
-# 1. Source this script.
-# 2. Define the functions build_tests(), unit_tests() and
-#    integration_tests(). They should run all tests (i.e., not fail
-#    fast), and return 0 if all passed, 1 if a failure occurred.
-#    The environment variables RUN_BUILD_TESTS, RUN_UNIT_TESTS and
-#    RUN_INTEGRATION_TESTS are set to 0 (false) or 1 (true) accordingly.
-#    If --emit-metrics is passed, EMIT_METRICS will be set to 1.
-# 3. Call the main() function passing $@ (without quotes).
-#
-# Running the script without parameters, or with the --all-tests
-# flag, causes all tests to be executed, in the right order.
-# Use the flags --build-tests, --unit-tests and --integration-tests
-# to run a specific set of tests. The flag --emit-metrics is used
-# to emit metrics when running the tests.
+# This is a helper script for Knative presubmit test scripts.
+# See README.md for instructions on how to use it.
 
 source $(dirname ${BASH_SOURCE})/library.sh
 
 # Extensions or file patterns that don't require presubmit tests.
-readonly NO_PRESUBMIT_FILES=(\.md \.png ^OWNERS)
+readonly NO_PRESUBMIT_FILES=(\.md \.png ^OWNERS ^OWNERS_ALIASES)
 
 # Options set by command-line flags.
 RUN_BUILD_TESTS=0
@@ -61,62 +48,114 @@ function exit_if_presubmit_not_required() {
   fi
 }
 
+function abort() {
+  echo "error: $@"
+  exit 1
+}
+
 # Process flags and run tests accordingly.
 function main() {
   exit_if_presubmit_not_required
 
-  local all_parameters=$@
-  [[ -z $1 ]] && all_parameters="--all-tests"
+  # Show the version of the tools we're using
+  if (( IS_PROW )); then
+    # Disable gcloud update notifications
+    gcloud config set component_manager/disable_update_check true
+    header "Current test setup"
+    echo ">> gcloud SDK version"
+    gcloud version
+    echo ">> kubectl version"
+    kubectl version
+    echo ">> go version"
+    go version
+    echo ">> git version"
+    git version
+  fi
 
-  for parameter in ${all_parameters}; do
+  [[ -z $1 ]] && set -- "--all-tests"
+
+  local TEST_TO_RUN=""
+
+  while [[ $# -ne 0 ]]; do
+    local parameter=$1
     case ${parameter} in
+      --build-tests) RUN_BUILD_TESTS=1 ;;
+      --unit-tests) RUN_UNIT_TESTS=1 ;;
+      --integration-tests) RUN_INTEGRATION_TESTS=1 ;;
+      --emit-metrics) EMIT_METRICS=1 ;;
       --all-tests)
         RUN_BUILD_TESTS=1
         RUN_UNIT_TESTS=1
         RUN_INTEGRATION_TESTS=1
+        ;;
+      --run-test)
         shift
+        [[ $# -ge 1 ]] || abort "missing executable after --run-test"
+        TEST_TO_RUN=$1
         ;;
-      --build-tests)
-        RUN_BUILD_TESTS=1
-        shift
-        ;;
-      --unit-tests)
-        RUN_UNIT_TESTS=1
-        shift
-        ;;
-      --integration-tests)
-        RUN_INTEGRATION_TESTS=1
-        shift
-        ;;
-      --emit-metrics)
-        EMIT_METRICS=1
-        shift
-        ;;
-      *)
-        echo "error: unknown option ${parameter}"
-        exit 1
-        ;;
+      *) abort "error: unknown option ${parameter}" ;;
     esac
+    shift
   done
 
   readonly RUN_BUILD_TESTS
   readonly RUN_UNIT_TESTS
   readonly RUN_INTEGRATION_TESTS
   readonly EMIT_METRICS
+  readonly TEST_TO_RUN
 
   cd ${REPO_ROOT_DIR}
 
   # Tests to be performed, in the right order if --all-tests is passed.
 
-  local result=0
+  local failed=0
+
+  if [[ -n "${TEST_TO_RUN}" ]]; then
+    if (( RUN_BUILD_TESTS || RUN_UNIT_TESTS || RUN_INTEGRATION_TESTS )); then
+      abort "--run-test must be used alone"
+    fi
+    ${TEST_TO_RUN} || failed=1
+  fi
+
   if (( RUN_BUILD_TESTS )); then
-    build_tests || result=1
+    build_tests || failed=1
   fi
   if (( RUN_UNIT_TESTS )); then
-    unit_tests || result=1
+    unit_tests || failed=1
   fi
   if (( RUN_INTEGRATION_TESTS )); then
-    integration_tests || result=1
+    local e2e_failed=0
+    # Run pre-integration tests, if any
+    if function_exists pre_integration_tests; then
+      if ! pre_integration_tests; then
+        failed=1
+        e2e_failed=1
+      fi
+    fi
+    # Don't run integration tests if pre-integration tests failed
+    if (( ! e2e_failed )); then
+      if function_exists integration_tests; then
+        if ! integration_tests; then
+          failed=1
+          e2e_failed=1
+        fi
+      else
+       local options=""
+       (( EMIT_METRICS )) && options="--emit-metrics"
+       for e2e_test in ./test/e2e-*tests.sh; do
+         echo "Running integration test ${e2e_test}"
+         if ! ${e2e_test} ${options}; then
+           failed=1
+           e2e_failed=1
+         fi
+       done
+      fi
+    fi
+    # Don't run post-integration
+    if (( ! e2e_failed )) && function_exists post_integration_tests; then
+      post_integration_tests || failed=1
+    fi
   fi
-  exit ${result}
+
+  exit ${failed}
 }

--- a/vendor/github.com/knative/test-infra/scripts/release.sh
+++ b/vendor/github.com/knative/test-infra/scripts/release.sh
@@ -14,27 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is a helper script for Knative release scripts. To use it:
-# 1. Source this script.
-# 2. Call the parse_flags() function passing $@ (without quotes).
-# 3. Call the run_validation_tests() passing the script or executable that
-#    runs the release validation tests.
-# 4. Write logic for the release process. Use the following boolean (0 is
-#    false, 1 is true) environment variables for the logic:
-#    SKIP_TESTS: true if --skip-tests is passed. This is handled automatically
-#                by the run_validation_tests() function.
-#    TAG_RELEASE: true if --tag-release is passed. In this case, the
-#                 environment variable TAG will contain the release tag in the
-#                 form vYYYYMMDD-<commit_short_hash>.
-#    PUBLISH_RELEASE: true if --publish is passed. In this case, the environment
-#                     variable KO_FLAGS will be updated with the -L option.
-#    SKIP_TESTS, TAG_RELEASE and PUBLISH_RELEASE default to false for safety.
-#    All environment variables above, except KO_FLAGS, are marked read-only once
-#    parse_flags() is called.
+# This is a helper script for Knative release scripts.
+# See README.md for instructions on how to use it.
 
 source $(dirname ${BASH_SOURCE})/library.sh
 
 # Simple banner for logging purposes.
+# Parameters: $1 - message to display.
 function banner() {
     make_banner "@" "$1"
 }
@@ -45,8 +31,10 @@ function banner() {
 #             $3 - tag to apply (optional).
 function tag_images_in_yaml() {
   [[ -z $3 ]] && return 0
-  echo "Tagging images with $3"
-  for image in $(grep -o "$2/[a-z\./-]\+@sha256:[0-9a-f]\+" $1); do
+  local src_dir="${GOPATH}/src/"
+  local BASE_PATH="${REPO_ROOT_DIR/$src_dir}"
+  echo "Tagging images under '${BASE_PATH}' with $3"
+  for image in $(grep -o "$2/${BASE_PATH}/[a-z\./-]\+@sha256:[0-9a-f]\+" $1); do
     gcloud -q container images add-tag ${image} ${image%%@*}:$3
   done
 }
@@ -57,54 +45,92 @@ function tag_images_in_yaml() {
 #             $3 - tag to apply (optional).
 function publish_yaml() {
   gsutil cp $1 gs://$2/latest/
-  [[ -n $3 ]] && gsutil cp $1 gs://$2/previous/$3/
+  [[ -n $3 ]] && gsutil cp $1 gs://$2/previous/$3/ || true
 }
 
+# These are global environment variables.
 SKIP_TESTS=0
 TAG_RELEASE=0
 PUBLISH_RELEASE=0
+BRANCH_RELEASE=0
 TAG=""
-KO_FLAGS="-P -L"
+RELEASE_VERSION=""
+RELEASE_NOTES=""
+RELEASE_BRANCH=""
+KO_FLAGS=""
+
+function abort() {
+  echo "error: $@"
+  exit 1
+}
 
 # Parses flags and sets environment variables accordingly.
 function parse_flags() {
+  TAG=""
+  RELEASE_VERSION=""
+  RELEASE_NOTES=""
+  RELEASE_BRANCH=""
+  KO_FLAGS="-P"
   cd ${REPO_ROOT_DIR}
-  for parameter in $@; do
+  while [[ $# -ne 0 ]]; do
+    local parameter=$1
     case $parameter in
       --skip-tests) SKIP_TESTS=1 ;;
       --tag-release) TAG_RELEASE=1 ;;
       --notag-release) TAG_RELEASE=0 ;;
-      --publish)
-        PUBLISH_RELEASE=1
-        # Remove -L from ko flags
-        KO_FLAGS="${KO_FLAGS/-L}"
-        ;;
-      --nopublish)
-        PUBLISH_RELEASE=0
-        # Add -L to ko flags
-        KO_FLAGS="-L ${KO_FLAGS}"
+      --publish) PUBLISH_RELEASE=1 ;;
+      --nopublish) PUBLISH_RELEASE=0 ;;
+      --version)
         shift
+        [[ $# -ge 1 ]] || abort "missing version after --version"
+        [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || abort "version format must be '[0-9].[0-9].[0-9]'"
+        RELEASE_VERSION=$1
         ;;
-      *)
-        echo "error: unknown option ${parameter}"
-        exit 1
+      --branch)
+        shift
+        [[ $# -ge 1 ]] || abort "missing branch after --commit"
+        [[ $1 =~ ^release-[0-9]+\.[0-9]+$ ]] || abort "branch name must be 'release-[0-9].[0-9]'"
+        RELEASE_BRANCH=$1
         ;;
+      --release-notes)
+        shift
+        [[ $# -ge 1 ]] || abort "missing release notes file after --release-notes"
+        [[ ! -f "$1" ]] && abort "file $1 doesn't exist"
+        RELEASE_NOTES=$1
+        ;;
+      *) abort "unknown option ${parameter}" ;;
     esac
     shift
   done
 
-  TAG=""
+  # Update KO_DOCKER_REPO and KO_FLAGS if we're not publishing.
+  if (( ! PUBLISH_RELEASE )); then
+    KO_DOCKER_REPO="ko.local"
+    KO_FLAGS="-L ${KO_FLAGS}"
+  fi
+
   if (( TAG_RELEASE )); then
-    # Currently we're not considering the tags in refs/tags namespace.
-    commit=$(git describe --always --dirty)
+    # Get the commit, excluding any tags but keeping the "dirty" flag
+    local commit="$(git describe --always --dirty --match '^$')"
+    [[ -n "${commit}" ]] || abort "Error getting the current commit"
     # Like kubernetes, image tag is vYYYYMMDD-commit
     TAG="v$(date +%Y%m%d)-${commit}"
   fi
 
+  if [[ -n "${RELEASE_VERSION}" ]]; then
+    TAG="v${RELEASE_VERSION}"
+  fi
+
+  [[ -n "${RELEASE_VERSION}" ]] && (( PUBLISH_RELEASE )) && BRANCH_RELEASE=1
+
   readonly SKIP_TESTS
   readonly TAG_RELEASE
   readonly PUBLISH_RELEASE
+  readonly BRANCH_RELEASE
   readonly TAG
+  readonly RELEASE_VERSION
+  readonly RELEASE_NOTES
+  readonly RELEASE_BRANCH
 }
 
 # Run tests (unless --skip-tests was passed). Conveniently displays a banner indicating so.
@@ -113,6 +139,46 @@ function run_validation_tests() {
   if (( ! SKIP_TESTS )); then
     banner "Running release validation tests"
     # Run tests.
-    $1
+    if ! $1; then
+      banner "Release validation tests failed, aborting"
+      exit 1
+    fi
   fi
+}
+
+# Initialize everything (flags, workspace, etc) for a release.
+function initialize() {
+  parse_flags $@
+  # Checkout specific branch, if necessary
+  if (( BRANCH_RELEASE )); then
+    git checkout upstream/${RELEASE_BRANCH} || abort "cannot checkout branch ${RELEASE_BRANCH}"
+  fi
+}
+
+# Create a new release on GitHub, also git tagging it (unless this is not a versioned release).
+# Parameters: $1 - Module name (e.g., "Knative Serving").
+#             $2 - YAML files to add to the release, space separated.
+function branch_release() {
+  (( BRANCH_RELEASE )) || return 0
+  local title="$1 release ${TAG}"
+  local attachments=()
+  local description="$(mktemp)"
+  local attachments_dir="$(mktemp -d)"
+  # Copy each YAML to a separate dir
+  for yaml in $2; do
+    cp ${yaml} ${attachments_dir}/
+    attachments+=("--attach=${yaml}#$(basename ${yaml})")
+  done
+  echo -e "${title}\n" > ${description}
+  if [[ -n "${RELEASE_NOTES}" ]]; then
+    cat ${RELEASE_NOTES} >> ${description}
+  fi
+  git tag -a ${TAG} -m "${title}"
+  git push $(git remote get-url upstream) tag ${TAG}
+  run_go_tool github.com/github/hub hub release create \
+      --prerelease \
+      ${attachments[@]} \
+      --file=${description} \
+      --commitish=${RELEASE_BRANCH} \
+      ${TAG}
 }


### PR DESCRIPTION
Old images cleanup is no longer part of e2e test, this functionality will be moved to a separate job runs periodically.

## Proposed Changes
  *This part is done in knative/test-infra, updating dependencies in this repo to include this update.

Link to the issue in test-infra: knative/test-infra#276
