### PR TITLE
Use `/usr/bin/env bash` instead of `/bin/bash`

### DIFF
--- a/hack/boilerplate/add-boilerplate.sh
+++ b/hack/boilerplate/add-boilerplate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Knative Authors
 #

--- a/hack/boilerplate/boilerplate.sh.txt
+++ b/hack/boilerplate/boilerplate.sh.txt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Knative Authors
 #

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Knative Authors
 #

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Knative Authors
 #

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Knative Authors
 #

--- a/test/presubmit-tests.sh
+++ b/test/presubmit-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2018 The Knative Authors
 #


### PR DESCRIPTION
Some systems may not have /bin/bash (NixOS for example)… Using
/usr/bin/env bash has the benefit of looking for whatever the
default version of the program is in your current environment

Same as knative/build#387, knative/pkg#107, …

/assign @adrcunha @mattmoor 

I realized I didn't update `caching` at the time I did that elsewhere :sweat: 

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
