### PR TITLE
Enable status subresource on Knative's 'Image' cache resource

### DIFF
--- a/config/image.yaml
+++ b/config/image.yaml
@@ -30,3 +30,5 @@ spec:
     shortNames:
     - img
   scope: Namespaced
+  subresources:
+    status: {}


### PR DESCRIPTION
<!--
Pro-tip: To automatically close issues when a PR is merged,
include the following in your PR description:

Fixes: <LINK TO ISSUE>
-->

On Kubernetes clusters v1.11+ this will trigger the `metadata.generation` to increment when edit's are made to the spec of an 'Image' resource