### PR TITLE
Add a label knative.dev/crd-install to CRDs to allow installing CRDs in a separate pass.

### DIFF
--- a/config/image.yaml
+++ b/config/image.yaml
@@ -16,6 +16,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: images.caching.internal.knative.dev
+  labels:
+    knative.dev/crd-install: true
 spec:
   group: caching.internal.knative.dev
   version: v1alpha1


### PR DESCRIPTION
## Proposed Changes

- Label CRDs so that they can be installed first with `kubectl -l knative.dev/crd-install=true YAML_FILE`

**Release Note**

```release-note
- CRDs are now labelled with knative.dev/crd-install=true to allow installing without race conditions or kubectl errors.
```