### PR TITLE
Fix knative.dev/crd-install label to match label schema types.

### DIFF
--- a/config/image.yaml
+++ b/config/image.yaml
@@ -17,7 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   name: images.caching.internal.knative.dev
   labels:
-    knative.dev/crd-install: true
+    knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev
   version: v1alpha1

--- a/config/image.yaml
+++ b/config/image.yaml
@@ -16,6 +16,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: images.caching.internal.knative.dev
+  labels:
+    knative.dev/crd-install: true
 spec:
   group: caching.internal.knative.dev
   version: v1alpha1


### PR DESCRIPTION
Spell `true` in a way that works for labels, as `"true"`.