### PR TITLE
Remove unnecessary caching-reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,6 +2,3 @@
 
 approvers:
 - caching-approvers
-
-reviewers:
-- caching-reviewers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,10 +3,6 @@ aliases:
   - evankanderson
   - mattmoor
   - vaikas-google
-  caching-reviewers:
-  - evankanderson
-  - mattmoor
-  - vaikas-google
 
   productivity-approvers:
   - adrcunha


### PR DESCRIPTION
Keep the repo reviewers as they were before (as /hack and /test are fine).

Part of knative/test-infra#579