### PR TITLE
Stop printing images.caching.internal.knative.dev resource in kubectl get all

### DIFF
--- a/config/image.yaml
+++ b/config/image.yaml
@@ -26,7 +26,6 @@ spec:
     plural: images
     singular: image
     categories:
-    - all
     - knative-internal
     - caching
     shortNames:


### PR DESCRIPTION
Currently `kubectl get all` outputs
`images.caching.internal.knative.dev`, but it is one of internal CRDs
and not necessary to examine the output in general.

This patch removes `-all` from categories to stop printing
images.caching.internal.knative.dev in kubectl get all.