### PR TITLE
Use CRD v1 APIs

### DIFF
--- a/config/image.yaml
+++ b/config/image.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: images.caching.internal.knative.dev

--- a/config/image.yaml
+++ b/config/image.yaml
@@ -20,7 +20,16 @@ metadata:
     knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
   names:
     kind: Image
     plural: images
@@ -31,5 +40,3 @@ spec:
     shortNames:
     - img
   scope: Namespaced
-  subresources:
-    status: {}


### PR DESCRIPTION
Upgrade `apiextensions.k8s.io/v1` with knative/serving.

See: https://github.com/knative/serving/pull/8259, https://github.com/knative/serving/issues/6584 and https://github.com/knative/serving/issues/6582.

TODO: 
- [ ] upgrade the knative/serving package