### PR TITLE
Check multiple entries in the validation.

### DIFF
--- a/pkg/apis/caching/v1alpha1/image_validation.go
+++ b/pkg/apis/caching/v1alpha1/image_validation.go
@@ -30,7 +30,7 @@ func (rt *Image) Validate(ctx context.Context) *apis.FieldError {
 	return rt.Spec.Validate(ctx).ViaField("spec")
 }
 
-func (rs *ImageSpec) Validate(ctx context.Context) *apis.FieldError {
+func (rs *ImageSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
 	if rs.Image == "" {
 		return apis.ErrMissingField("image")
 	}
@@ -39,8 +39,8 @@ func (rs *ImageSpec) Validate(ctx context.Context) *apis.FieldError {
 	// https://github.com/google/go-containerregistry/blob/2f3e3e1/pkg/name/ref.go#L41
 	for index, ips := range rs.ImagePullSecrets {
 		if equality.Semantic.DeepEqual(ips, corev1.LocalObjectReference{}) {
-			return apis.ErrMissingField(fmt.Sprintf("imagePullSecrets[%d].name", index))
+			errs = errs.Also(apis.ErrMissingField(fmt.Sprintf("imagePullSecrets[%d].name", index)))
 		}
 	}
-	return nil
+	return errs
 }

--- a/pkg/apis/caching/v1alpha1/image_validation_test.go
+++ b/pkg/apis/caching/v1alpha1/image_validation_test.go
@@ -51,6 +51,18 @@ func TestImageValidation(t *testing.T) {
 			},
 		},
 		want: apis.ErrMissingField("spec.imagePullSecrets[0].name"),
+	}, {
+		name: "nested multiple spec errors",
+		r: &Image{
+			Spec: ImageSpec{
+				Image: "busybox",
+				ImagePullSecrets: []corev1.LocalObjectReference{{
+					Name: "frankie",
+				}, {}, {}},
+			},
+		},
+		want: apis.ErrMissingField("spec.imagePullSecrets[1].name").
+			Also(apis.ErrMissingField("spec.imagePullSecrets[2].name")),
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
This is a list and we check all of them to be conformant, but return only first error,
which is a departure from what we do in most of the serving.

/assign mattmoor
