### PR TITLE
Update OWNERS_ALIASES to match autogen in community

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,4 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- caching-approvers
+- serving-writers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,5 +1,5 @@
 aliases:
-  caching-approvers:
+  serving-writers:
   - dprotaso
   - evankanderson
   - grantr
@@ -9,7 +9,7 @@ aliases:
   - vagababov
   - vaikas
 
-  productivity-approvers:
+  productivity-writers:
   - chaodaiG
   - chizhg
   productivity-reviewers:

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- productivity-approvers
+- productivity-writers
 
 reviewers:
 - productivity-reviewers

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- productivity-approvers
+- productivity-writers
 
 reviewers:
 - productivity-reviewers


### PR DESCRIPTION
See https://github.com/knative/community/pull/552 for the addition of groups/full OWNERS_ALIASES that will be synced.

This is a preparatory PR for landing OWNERS_ALIASES automation across the Knative org (alternative to the CODEOWNERS changes in knative-sandbox).

If this seems to be expanding permissions or otherwise likely to cause a problem, `/hold` this PR and comment here or on https://github.com/knative/community/pull/552.
