### PR TITLE
Remove shortnames for internal resources

### DIFF
--- a/config/image.yaml
+++ b/config/image.yaml
@@ -29,8 +29,6 @@ spec:
     categories:
     - knative-internal
     - caching
-    shortNames:
-    - img
   scope: Namespaced
   versions:
   - name: v1alpha1


### PR DESCRIPTION
This is an internal resource, so adding a shortname doesn't really make sense.

It also conflicts with shortnames for public resources in (at least) the `kpack.io` namespace: https://github.com/pivotal/kpack/blob/main/config/image.yaml#L55

It seems like `kn` or `ca` sorts before `kp`, which causes Kubernetes to prefer this shortname over the `kpack.io` public resource name.

/assign @dprotaso 