### PR TITLE
bump controller-tools version when updating schema

### DIFF
--- a/config/image.yaml
+++ b/config/image.yaml
@@ -38,14 +38,25 @@ spec:
         status: {}
       schema:
         openAPIV3Schema:
-          description: Image is a Knative abstraction that encapsulates the interface by which Knative components express a desire to have a particular image cached.
+          description: |-
+            Image is a Knative abstraction that encapsulates the interface by which Knative
+            components express a desire to have a particular image cached.
           type: object
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -59,25 +70,40 @@ spec:
                   description: Image is the name of the container image url to cache across the cluster.
                   type: string
                 imagePullSecrets:
-                  description: ImagePullSecrets contains the names of the Kubernetes Secrets containing login information used by the Pods which will run this container.
+                  description: |-
+                    ImagePullSecrets contains the names of the Kubernetes Secrets containing login
+                    information used by the Pods which will run this container.
                   type: array
                   items:
-                    description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
+                    description: |-
+                      LocalObjectReference contains enough information to let you locate the
+                      referenced object inside the same namespace.
                     type: object
                     properties:
                       name:
-                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?
                         type: string
                     x-kubernetes-map-type: atomic
                 serviceAccountName:
-                  description: 'ServiceAccountName is the name of the Kubernetes ServiceAccount as which the Pods will run this container.  This is potentially used to authenticate the image pull if the service account has attached pull secrets.  For more information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account'
+                  description: |-
+                    ServiceAccountName is the name of the Kubernetes ServiceAccount as which the Pods
+                    will run this container.  This is potentially used to authenticate the image pull
+                    if the service account has attached pull secrets.  For more information:
+                    https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account
                   type: string
             status:
               description: Status communicates the observed state of the Image (from the controller).
               type: object
               properties:
                 annotations:
-                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  description: |-
+                    Annotations is additional Status fields for the Resource to save some
+                    additional State as well as convey more information to the user. This is
+                    roughly akin to Annotations on any k8s resource, just the reconciler conveying
+                    richer information outwards.
                   type: object
                   additionalProperties:
                     type: string
@@ -85,14 +111,19 @@ spec:
                   description: Conditions the latest available observations of a resource's current state.
                   type: array
                   items:
-                    description: 'Condition defines a readiness condition for a Knative resource. See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties'
+                    description: |-
+                      Condition defines a readiness condition for a Knative resource.
+                      See: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties
                     type: object
                     required:
                       - status
                       - type
                     properties:
                       lastTransitionTime:
-                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        description: |-
+                          LastTransitionTime is the last time the condition transitioned from one status to another.
+                          We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic
+                          differences (all other things held constant).
                         type: string
                       message:
                         description: A human readable message indicating details about the transition.
@@ -101,7 +132,9 @@ spec:
                         description: The reason for the condition's last transition.
                         type: string
                       severity:
-                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        description: |-
+                          Severity with which to treat failures of this type of condition.
+                          When this is not specified, it defaults to Error.
                         type: string
                       status:
                         description: Status of the condition, one of True, False, Unknown.
@@ -110,7 +143,9 @@ spec:
                         description: Type of condition.
                         type: string
                 observedGeneration:
-                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  description: |-
+                    ObservedGeneration is the 'Generation' of the Service that
+                    was last processed by the controller.
                   type: integer
                   format: int64
       additionalPrinterColumns:

--- a/hack/update-schemas.sh
+++ b/hack/update-schemas.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2 \
+go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0 \
   schemapatch:manifests=config/,generateEmbeddedObjectMeta=false \
   output:dir=config \
   paths=./pkg/apis/...


### PR DESCRIPTION
/assign @izabelacg 

This unblocks updating dependencies for this repo - older versions of controller-gen doesn't work with go1.22