### PR TITLE
bump controller-gen to v0.17.0

### DIFF
--- a/config/image.yaml
+++ b/config/image.yaml
@@ -86,9 +86,7 @@ spec:
                           This field is effectively required, but due to backwards compatibility is
                           allowed to be empty. Instances of this type with an empty value here are
                           almost certainly wrong.
-                          TODO: Add other useful fields. apiVersion, kind, uid?
                           More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                         type: string
                         default: ""
                     x-kubernetes-map-type: atomic

--- a/hack/update-schemas.sh
+++ b/hack/update-schemas.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0 \
+go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.17.0 \
   schemapatch:manifests=config/,generateEmbeddedObjectMeta=false \
   output:dir=config \
   paths=./pkg/apis/...


### PR DESCRIPTION
Knobots is failing to update this repo - I'm guessing it's because we have an older controller-gen version

/assign @skonto 